### PR TITLE
Add odh-ai-fifth-demo to bundle-patch.yaml

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -180,6 +180,8 @@ ARG ODH_PIPELINES_COMPONENTS_GIT_URL=
 ARG ODH_PIPELINES_COMPONENTS_GIT_COMMIT=
 ARG ODH_MODEL_SERVING_API_GIT_URL=
 ARG ODH_MODEL_SERVING_API_GIT_COMMIT=
+ARG ODH_AI_FIFTH_DEMO_GIT_URL=
+ARG ODH_AI_FIFTH_DEMO_GIT_COMMIT=
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -376,7 +378,9 @@ LABEL \
       odh-pipelines-components.git.url="${ODH_PIPELINES_COMPONENTS_GIT_URL}" \
       odh-pipelines-components.git.commit="${ODH_PIPELINES_COMPONENTS_GIT_COMMIT}" \
       odh-model-serving-api.git.url="${ODH_MODEL_SERVING_API_GIT_URL}" \
-      odh-model-serving-api.git.commit="${ODH_MODEL_SERVING_API_GIT_COMMIT}"
+      odh-model-serving-api.git.commit="${ODH_MODEL_SERVING_API_GIT_COMMIT}" \
+      odh-ai-fifth-demo.git.url="${ODH_AI_FIFTH_DEMO_GIT_URL}" \
+      odh-ai-fifth-demo.git.commit="${ODH_AI_FIFTH_DEMO_GIT_COMMIT}"
 # Copy files to locations specified by labels.
 
 LABEL com.redhat.component="odh-operator-bundle" \

--- a/bundle/bundle-patch.yaml
+++ b/bundle/bundle-patch.yaml
@@ -216,6 +216,8 @@ patch:
     - name: RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE
       value: "quay.io/rhoai/odh-kserve-autogluon-server-rhel9@sha256:a3c901e75472ce551d49a79161115faa4ee60300e5a0c5060cc2acc64fed7d96"
 
+    - name: RELATED_IMAGE_ODH_AI_FIFTH_DEMO_IMAGE
+      value: quay.io/rhoai/odh-ai-fifth-demo-rhel9@sha256:6487e9c28de964341f96ed14e369c1e7cb97091225703c291661f98e3041a09e
   additional-related-images:
     file: additional-images-patch.yaml
   additional-fields:

--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -109,6 +109,7 @@ config:
         rhoai/odh-llm-d-batch-gateway-gc-rhel9: rhoai/odh-llm-d-batch-gateway-gc-rhel9
         rhoai/odh-model-serving-api-rhel9: rhoai/odh-model-serving-api-rhel9
         rhoai/odh-kserve-autogluon-server-rhel9: rhoai/odh-kserve-autogluon-server-rhel9
+        rhoai/odh-ai-fifth-demo-rhel9: rhoai/odh-ai-fifth-demo-rhel9
   supported-ocp-versions:
     build:
       - name: v4.19


### PR DESCRIPTION
Adds 'odh-ai-fifth-demo' to the rhoai-rhtap/RHOAI-Build-Config bundle relatedImages.

Component: odh-ai-fifth-demo
Product context: RHOAI
Quay org: rhoai
Upstream repo: https://github.com/rhoai-rhtap/odh-ai-fifth-demo @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHODS-14227

**Files changed:**
- `bundle/bundle-patch.yaml` — added `RELATED_IMAGE_ODH_AI_FIFTH_DEMO_IMAGE` to `patch.relatedImages`
- `config/build-config.yaml` — added `rhoai/odh-ai-fifth-demo-rhel9` to `config.replacements[0].repo_mappings` (RHOAI only)
- `bundle/Dockerfile` — added ARG `ODH_AI_FIFTH_DEMO_GIT_URL`, ARG `ODH_AI_FIFTH_DEMO_GIT_COMMIT`, and git label entries for `odh-ai-fifth-demo` (RHOAI only)

> **NOTE:** The SHA256 digest for `RELATED_IMAGE_ODH_AI_FIFTH_DEMO_IMAGE` is a **placeholder** — the image has not yet been built by Konflux.
> Before merging this PR, replace the digest with the real value:
> ```
> skopeo inspect --no-creds docker://quay.io/rhoai/odh-ai-fifth-demo:odh-stable | jq -r '.Digest'
> ```